### PR TITLE
autoload: Fix normal! gg to use keepjump

### DIFF
--- a/autoload/hlgoimport.vim
+++ b/autoload/hlgoimport.vim
@@ -14,7 +14,7 @@ function! hlgoimport#update(forced) abort
   let end = 0
   let view = winsaveview()
 
-  normal! gg
+  keepjumps normal! gg
   let start = search(s:multi_import, 'cW')
   if start
     let end = search(s:multi_import, 'ceW')


### PR DESCRIPTION
When jump to other source(like `<C-]>`), hlgoimport.vim parses import
section use 'gg' and changed jumplist.
After that, if want to back to previous buffer use <C-o>, will be
jump to hlgoimport.vim's saved positon.
