### PR TITLE
plugin: fix conflict with neosnippet.vim

### DIFF
--- a/autoload/hlgoimport.vim
+++ b/autoload/hlgoimport.vim
@@ -14,7 +14,7 @@ function! hlgoimport#update(forced) abort
   let end = 0
   let view = winsaveview()
 
-  keepjumps normal! gg
+  call cursor(1, 1)
   let start = search(s:multi_import, 'cW')
   if start
     let end = search(s:multi_import, 'ceW')


### PR DESCRIPTION
Fix conflict with Shougo/neosnippet.vim.

When expand snippet use neosnippet.vim, neosnippet can't insert mode because before called `keepjumps normal! gg`(? I'm not sure).

~~So, change the call `hlgoimport#update(0)` to insert mode only.~~
**Edit:** The solution is change `normal! gg` to `call cursor(1, 1)`
